### PR TITLE
Migration vers Dotnet 7

### DIFF
--- a/Cryptography/Cryptography/Cryptography.csproj
+++ b/Cryptography/Cryptography/Cryptography.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DebugType>embedded</DebugType>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>2.1.0</AssemblyVersion>
+    <FileVersion>2.1.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/LSZ/CRYPTO/CRYPTO.csproj
+++ b/LSZ/CRYPTO/CRYPTO.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <ApplicationIcon>CRYPICON.ICO</ApplicationIcon>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>2.1.0</AssemblyVersion>
+    <FileVersion>2.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LSZ/LORENZ/LORENZ.csproj
+++ b/LSZ/LORENZ/LORENZ.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Authors>JML</Authors>
     <Company>LORENZ SZ</Company>
     <Description>Application permettant de chiffrer et de déchiffrer des messages de type LORENZ uniquement. Chiffrer des messages n'aura jamais été aussi facile et accessible, tout en étant sécuritaire et fiable.</Description>

--- a/LSZ/LORENZ/Program.cs
+++ b/LSZ/LORENZ/Program.cs
@@ -6,7 +6,7 @@ namespace LORENZ
 {
     class Program
     {
-        public static string VersionNumber => "3.0.0-alpha";
+        public static string VersionNumber => "3.0.0-beta";
         private static bool OverridePress { get; set; }
 
         public static void Main()

--- a/LSZ/LZKEYGEN/LZKEYGEN.csproj
+++ b/LSZ/LZKEYGEN/LZKEYGEN.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TreeRegister/TreeRegister.csproj
+++ b/TreeRegister/TreeRegister.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 	<DebugType>embedded</DebugType>
   </PropertyGroup>
 


### PR DESCRIPTION
La version .NET 7 étant déjà sortie depuis le 8 novembre 2022, il m'apparait sensé de migrer LORENZ vers cette nouvelle plateforme.